### PR TITLE
Use minimum lux config

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,7 +88,7 @@ class FroniusInverter {
         .setCharacteristic(Characteristic.SerialNumber, this.serial)
 
         this.service.getCharacteristic(Characteristic.CurrentAmbientLightLevel)
-		  .on('get', this.getOnCharacteristicHandler.bind(this))
+		  .on('get', this.getCurrentAmbientLightLevelHandler.bind(this))
 		  .setProps({
 			minValue: this.minLux
 		  });
@@ -96,8 +96,8 @@ class FroniusInverter {
 	    return [informationService, this.service]
     }
 
-    async getOnCharacteristicHandler (callback) {
-	    this.log(`calling getOnCharacteristicHandler`, await getAccessoryValue(this.ip, this.inverter_data))
+    async getCurrentAmbientLightLevelHandler (callback) {
+	    this.log(`calling getCurrentAmbientLightLevelcHandler`, await getAccessoryValue(this.ip, this.inverter_data))
 
 	    callback(null, await getAccessoryValue(this.ip, this.inverter_data))
 	}

--- a/index.js
+++ b/index.js
@@ -88,7 +88,10 @@ class FroniusInverter {
         .setCharacteristic(Characteristic.SerialNumber, this.serial)
 
         this.service.getCharacteristic(Characteristic.CurrentAmbientLightLevel)
-	      .on('get', this.getOnCharacteristicHandler.bind(this))
+		  .on('get', this.getOnCharacteristicHandler.bind(this))
+		  .setProps({
+			minValue: this.minLux
+		  });
 
 	    return [informationService, this.service]
     }

--- a/index.js
+++ b/index.js
@@ -97,8 +97,10 @@ class FroniusInverter {
     }
 
     async getCurrentAmbientLightLevelHandler (callback) {
-	    this.log(`calling getCurrentAmbientLightLevelcHandler`, await getAccessoryValue(this.ip, this.inverter_data))
+		let getValue = await getAccessoryValue(this.ip, this.inverter_data)
 
-	    callback(null, await getAccessoryValue(this.ip, this.inverter_data))
+		this.log(`calling getCurrentAmbientLightLevelcHandler`, getValue)
+
+	    callback(null, getValue)
 	}
 }


### PR DESCRIPTION
- Allows minimum value to be 0, rather than default of `0.0001`
- Renamed `getOnCharacteristicHandler` to `getCurrentAmbientLightLevelHandler` to make it easier to follow
- Only call the Fronius API once (rather than once for logging and once for setting the value)